### PR TITLE
Fix final callback to be called

### DIFF
--- a/lib/wddoc.js
+++ b/lib/wddoc.js
@@ -54,7 +54,7 @@ exports.process = function(options, callback) {
         formatter: formatter
     },options);
 
-    async.each(glob.sync(options.inputDir + '**'), function(file, callback) {
+    async.each(glob.sync(options.inputDir + '**/*.js'), function(file, callback) {
 
         exports.parse(file, options, function(err, doc) {
 


### PR DESCRIPTION
The full async chain was not being fulfilled because glob.sync would include './../webdriverio/lib/commands' (a directory) as an array item when calling the process with `bin/wddoc -i ./../webdriverio/lib/commands/ -t ./templates/template.md.ejs`. The fix just corrects glob so that it only returns the array with filenames, not the directory path.