### PR TITLE
updated template to include Returns and Throws

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -27,7 +27,7 @@ formatter.format = function(docfile) {
 
         javadoc.tags.forEach(function(tag) {
 
-            if (tag.type == 'param') {
+            if (tag.type === 'param') {
                 tag.joinedTypes = tag.types.join('|');
 
                 if(tag.joinedTypes.indexOf('=') > -1) {

--- a/templates/template.md.ejs
+++ b/templates/template.md.ejs
@@ -43,6 +43,20 @@ browser.<?= docfile.filename.slice(0,-3) ?>(<?= command.paramStr ?>);
 <? }); ?>
 <? } ?>
 
+<? if (command.returnTags.length) { ?>
+### Returns
+
+<? command.returnTags.forEach(function(returnTag) { ?>- **&lt;<?= returnTag.joinedTypes.replace('=','').replace(/[|\/]/g,'/') ?>&gt;**: <?= returnTag.description ?>
+<? }) ?>
+<? } ?>
+
+<? if (command.throwsTags.length) { ?>
+### Throws
+
+<? command.throwsTags.forEach(function(throwsTag) { ?>- **<?= throwsTag.joinedTypes.replace('=','').replace(/[|\/]/g,'/') ?>**: <?= throwsTag.description ?>
+<? }) ?>
+<? } ?>
+
 <? mobileSupport = command.raw.tags.filter(function(raw){ return raw.type === 'for' }); ?>
 <? mobileSupport = mobileSupport.length ? mobileSupport[0].string.split(',') : null ?>
 <? if (mobileSupport && mobileSupport.length > 0) { ?>


### PR DESCRIPTION
Updated the doc template to include `@return` and `@throws` jsdoc attributes, if they are present.

Note: the library already in use here supports `@return` but not `@returns`. If you approve the PR, I don't mind going through the existing jsdocs on the webdriverio project and converting instances of `@returns` to `@return` for compatibility.