### PR TITLE
Removed 'browser.' from $ commands.

### DIFF
--- a/templates/template.md.ejs
+++ b/templates/template.md.ejs
@@ -22,7 +22,8 @@ description: "<?= description ?>"
 ### Usage
 
 ```js
-browser.<?= docfile.filename.slice(0,-3) ?>(<?= command.paramStr ?>);
+<? if (!docfile.filename.startsWith("$")) { ?>
+browser.<? }?><?= docfile.filename.slice(0,-3) ?>(<?= command.paramStr ?>);
 ```
 
 <? if (command.paramTags.length) { ?>


### PR DESCRIPTION
I added an if statement to the "Usage" portion of the document template, so that if the command starts with `$`, the `browser.` portion is not printed to the documentation. Because I used startsWith, this includes `$`, `$$`, and any future `$commands` that may eventually be added.